### PR TITLE
Update to new propTypes

### DIFF
--- a/src/Table.js
+++ b/src/Table.js
@@ -2,13 +2,14 @@
  * Created by Jeepeng on 2016/11/20.
  */
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import {
   StyleSheet,
   View,
   ScrollView,
   Text
 } from 'react-native'
+import PropTypes from 'prop-types'
 
 const DEFAULT_HEIGHT = 240;
 const DEFAULT_COLUMN_WIDTH = 60;

--- a/src/Table.js
+++ b/src/Table.js
@@ -24,8 +24,8 @@ class Table extends Component {
     })).isRequired,
     columnWidth: PropTypes.number,
     height: PropTypes.number,
-    dataSource: React.PropTypes.array.isRequired,
-    renderCell: React.PropTypes.func,
+    dataSource: PropTypes.array.isRequired,
+    renderCell: PropTypes.func,
   };
 
   static defaultProps = {


### PR DESCRIPTION
In React 15, proptypes come from a separate package.

This PR makes sure that this package still works in React 15